### PR TITLE
Fix/federated optimization

### DIFF
--- a/cameo/src/main/java/org/openmbee/mms/cameo/services/CameoNodeService.java
+++ b/cameo/src/main/java/org/openmbee/mms/cameo/services/CameoNodeService.java
@@ -85,7 +85,7 @@ public class CameoNodeService extends DefaultNodeService implements Hierarchical
         ElementsResponse response = new ElementsResponse();
         response.getElements().addAll(info.getActiveElementMap().values());
         response.setRejected(new ArrayList<>(info.getRejected().values()));
-        response.setCommitId(commitId);
+        response.setCommitId(resCommitId);
         return response;
     }
 

--- a/cameo/src/main/java/org/openmbee/mms/cameo/services/CameoNodeService.java
+++ b/cameo/src/main/java/org/openmbee/mms/cameo/services/CameoNodeService.java
@@ -44,12 +44,16 @@ public class CameoNodeService extends DefaultNodeService implements Hierarchical
             Map<String, String> params) {
 
         String commitId = params.getOrDefault(CrudConstants.COMMITID, null);
-        if (commitId == null && !optimizationConfig.isOptimizeForFederated()) {
+        String resCommitId = commitId;
+        if (commitId == null) {
             Optional<CommitJson> commitJson = commitPersistence.findLatestByProjectAndRef(projectId, refId);
             if (!commitJson.isPresent()) {
                 throw new InternalErrorException("Could not find latest commit for project and ref");
             }
-            commitId = commitJson.get().getId();
+            resCommitId = commitJson.get().getId();
+            if (!optimizationConfig.isOptimizeForFederated()) {
+                commitId = resCommitId;
+            }
         }
 
         NodeGetInfo info = getNodePersistence().findAll(projectId, refId, commitId, req.getElements());

--- a/cameo/src/main/java/org/openmbee/mms/cameo/services/CameoNodeService.java
+++ b/cameo/src/main/java/org/openmbee/mms/cameo/services/CameoNodeService.java
@@ -44,7 +44,7 @@ public class CameoNodeService extends DefaultNodeService implements Hierarchical
             Map<String, String> params) {
 
         String commitId = params.getOrDefault(CrudConstants.COMMITID, null);
-        if (commitId == null) {
+        if (commitId == null && !optimizationConfig.isOptimizeForFederated()) {
             Optional<CommitJson> commitJson = commitPersistence.findLatestByProjectAndRef(projectId, refId);
             if (!commitJson.isPresent()) {
                 throw new InternalErrorException("Could not find latest commit for project and ref");

--- a/crud/src/main/java/org/openmbee/mms/crud/config/OptimizationConfig.java
+++ b/crud/src/main/java/org/openmbee/mms/crud/config/OptimizationConfig.java
@@ -1,0 +1,21 @@
+package org.openmbee.mms.crud.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OptimizationConfig {
+
+    @Value("${mms.optimize-for-federated:true}")
+    private boolean optimizeForFederated;
+
+    public boolean isOptimizeForFederated() {
+        return optimizeForFederated;
+    }
+
+    public void setOptimizeForFederated(boolean optimizeForFederated) {
+        this.optimizeForFederated = optimizeForFederated;
+    }
+
+
+}

--- a/example/src/main/resources/application.properties.example
+++ b/example/src/main/resources/application.properties.example
@@ -3,6 +3,7 @@ mms.admin.username=test
 mms.admin.password=test
 
 mms.stream.batch.size=100000
+mms.optimize-for-federated=true
 
 #Comma Separated list of allowed cross site origins
 cors.allowed.origins=*

--- a/federatedpersistence/src/main/java/org/openmbee/mms/federatedpersistence/dao/FederatedCommitPersistence.java
+++ b/federatedpersistence/src/main/java/org/openmbee/mms/federatedpersistence/dao/FederatedCommitPersistence.java
@@ -135,13 +135,8 @@ public class FederatedCommitPersistence implements CommitPersistence {
         if(!commit.isPresent()) {
             return Optional.empty();
         }
-        Optional<CommitJson> commitJson = commitIndexDAO.findById(commit.get().getCommitId());
-        if(!commitJson.isPresent()) {
-            throw new InternalErrorException(
-                String.format("Federated data model inconsistency: Could not find commit json for commitId %s",
-                    commit.get().getCommitId()));
-        }
-        return commitJson;
+        CommitJson json = getJsonFromCommit(commit.get(), projectId);
+        return Optional.of(json);
     }
 
     @Override
@@ -155,13 +150,7 @@ public class FederatedCommitPersistence implements CommitPersistence {
         List<Commit> commitList = commitDAO.findByRefAndTimestampAndLimit(b, timestamp, limit);
         List<CommitJson> commits = new ArrayList<>();
         for (Commit c : commitList) {
-            CommitJson json = new CommitJson();
-            json.setCreated(Formats.FORMATTER.format(c.getTimestamp()));
-            json.setCreator(c.getCreator());
-            json.setId(c.getCommitId());
-            json.setComment(c.getComment());
-            json.setRefId(c.getBranchId());
-            json.setProjectId(projectId);
+            CommitJson json = getJsonFromCommit(c, projectId);
             commits.add(json);
         }
         return commits;
@@ -196,5 +185,16 @@ public class FederatedCommitPersistence implements CommitPersistence {
             return commitJsonOptional;
         }
         return Optional.empty();
+    }
+
+    private CommitJson getJsonFromCommit(Commit c, String projectId) {
+        CommitJson json = new CommitJson();
+        json.setCreated(Formats.FORMATTER.format(c.getTimestamp()));
+        json.setCreator(c.getCreator());
+        json.setId(c.getCommitId());
+        json.setComment(c.getComment());
+        json.setRefId(c.getBranchId());
+        json.setProjectId(projectId);
+        return json;
     }
 }

--- a/twc/README.rst
+++ b/twc/README.rst
@@ -3,7 +3,13 @@
 TWC
 ---
 
-The TWC Module provides integration with NoMagic's Teamwork Cloud.
+The TWC Module provides integration with NoMagic's Teamwork Cloud. For MDK SSO login integration, the MDK and TWC must be configured.
+
+TWC: TWC SSO must be configured correctly and working via the Single-Sign On tab when logging in to TWC from Cameo
+
+MDK: Under Options -> Environment -> MDK -> Set MMS Authentication Chain, add `org.openmbee.mdk.tickets.TWCAcquireTicketProcessor` to the front
+
+MMS: If the TWC api has a self-signed or private SSL cert, ensure the Java runtime running MMS has the root cert in its keystore
 
 Configuration
 ^^^^^^^^^^^^^

--- a/twc/src/main/java/org/openmbee/mms/twc/security/TwcUserDetailsService.java
+++ b/twc/src/main/java/org/openmbee/mms/twc/security/TwcUserDetailsService.java
@@ -43,6 +43,7 @@ public class TwcUserDetailsService implements UserDetailsService {
     public UserJson addUser(String username) {
         UserJson user = new UserJson();
         user.setUsername(username);
+        user.setAdmin(false);
         //TODO: fill in user details from TWC
         user.setEnabled(true);
         return userPersistence.save(user);


### PR DESCRIPTION
Adding config option to optimize element gets and ref commit gets if using federated persistence.
Federated persistence refactor introduced extra commit gets and checks when doing element/node gets, this reverts it back to previous behavior, also getting ref commits returns just commit metadata like before and not commit detail info (which requires a trip to elastic)